### PR TITLE
melhoria apresentação de card

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= stylesheet_link_tag "application" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
-
+<body>
     <header>
     <nav class="navbar navbar-expand-lg navbar-dark bg-default mb-4">
       <div class="container-fluid">
@@ -46,6 +46,7 @@
       </div>
     </nav>
     </header>
+    
     <main class="container">
       <div>
         <% if !notice.nil? %>
@@ -55,7 +56,10 @@
           <p class="alert alert-warning mt-4"><%= alert %></p>
         <% end %>
       </div>
+      <div class="container">
+  <!-- Content here -->
       <%= yield %>
+</div>
     </main>
   </body>
 </html>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,10 +1,8 @@
-<h1 class="display-6">Informações do Pedido</h1>
+<h2 class="display-6">Informações do Pedido</h2>
 <hr/>
-<div class="card" style="width: 20rem;">
+<div class="d-flex justify-content-between">
   <div class="card-body">
-    <div class="card-header">
-      <%= "#{Order.human_attribute_name(:order)}: #{@order.code}" %>
-    </div>
+    <h5 class="card-title mb-2"><%=Order.model_name.human %>: <%= @order.code %></h5>
     <p class="card-text"><%="#{Order.human_attribute_name(:insurance_name)}: #{@order.insurance_name}"%></p>
     <p class="card-text"><%="#{Order.human_attribute_name(:package_name)}: #{@order.package_name}"%></p>
     <p class="card-text"><%="#{Order.human_attribute_name(:contract_period)}: #{@order.contract_period} #{t :month, count: @order.contract_period}"%></p>
@@ -24,10 +22,14 @@
     <% end %>
     <p class="card-text"> <%= Order.human_attribute_name(:status) %>: <%= Order.human_attribute_name("status.#{@order.status}")%></p>
   </div>
-  <% @order.equipment.photos.each do |photo| %>
-    <%= image_tag photo, class:"card-img-top" %>
-    <% break %>
-  <% end %>
+  <div>
+    <div style="width: 20rem;">
+    <% @order.equipment.photos.each do |photo| %>
+      <%= image_tag photo, class:"card-img-top" %>
+      <% break %>
+    <% end %>
+    </div>
+  </div>
 </div>
 
 <% if @order.insurance_approved? %>


### PR DESCRIPTION
![Captura de Tela 2022-12-12 às 19 02 59](https://user-images.githubusercontent.com/61168540/207164857-efed5e02-209c-42d9-9427-9f43025a3d98.png)

Coloquei a apresentação do card dividida pois como o conteúdo dele era muito extenso, tinha que ficar descendo barra de rolagem e isso é desagradável para o usuário.
Também incluí a tradução de 'order' que estava faltando.